### PR TITLE
Update Create.php

### DIFF
--- a/src/Method/Payment/Create.php
+++ b/src/Method/Payment/Create.php
@@ -112,7 +112,10 @@ class Create implements MethodInterface
                     ]),
                     'cvc' => new Assert\Required([
                         new Assert\NotBlank(),
-                        new Assert\Type(['type' => 'string']),
+                        new Assert\Type(['type' => 'integer']),
+                        new Assert\Length([
+                            'max' => 4
+                        ]),
                     ]),
                     'holder' => new Assert\Required([
                         new Assert\NotBlank(),


### PR DESCRIPTION
To my knowledge CVC can be 3 or 4 digits. "Create new payment" example is 'cvc' => 456 integer and does not pass this validation rule.
