### PR TITLE
Set the strict option of the Choice Constraint

### DIFF
--- a/src/Method/Payment/Create.php
+++ b/src/Method/Payment/Create.php
@@ -81,7 +81,8 @@ class Create implements MethodInterface
                     'choices' => [
                         self::CARD,
                         self::RECURRING
-                    ]
+                    ],
+                    'strict' => true
                 ])
             ]),
             'payment_instrument' => $this->getPaymentInstrumentConstraints(


### PR DESCRIPTION
Setting the strict option of the Choice Constraint to `false` has been deprecated as of Symfony 3.2 and the option will be changed to `true` as of 4.0.

Without this option, it emits deprecation warning. Could be removed once Cardinity Client depends on Symfony 4+

https://symfony.com/doc/3.2/reference/constraints/Choice.html#strict