### PR TITLE
Fix threeds2_data serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ try {
     } elseif ($status == 'pending') {
         if ($payment->isThreedsV2()) {
             // $auth object for data required to finalize payment
-            $auth = $payment->getThreeds2data();
+            $auth = $payment->getThreeds2Data();
             // finalize process should be done here.
         }
     }

--- a/spec/Method/Payment/CreateSpec.php
+++ b/spec/Method/Payment/CreateSpec.php
@@ -27,8 +27,8 @@ class CreateSpec extends ObjectBehavior
             'country' => 'LT',
             'postal_code' => '0234'
         ];
-        $threeds2data['notification_url'] = 'http://localhost:8000/3dsv2_callback.php';
-        $threeds2data['browser_info'] = $browserInfo;
+        $threeds2Data['notification_url'] = 'http://localhost:8000/3dsv2_callback.php';
+        $threeds2Data['browser_info'] = $browserInfo;
 
         $this->options = [
             'amount' => 12.99,
@@ -45,7 +45,7 @@ class CreateSpec extends ObjectBehavior
                 'cvc' => '456',
                 'holder' => 'Mr Tester',
             ],
-            'threeds2_data' => $threeds2data
+            'threeds2_data' => $threeds2Data
         ];
         $this->beConstructedWith($this->options);
     }

--- a/spec/Method/Payment/PaymentSpec.php
+++ b/spec/Method/Payment/PaymentSpec.php
@@ -65,16 +65,16 @@ class PaymentSpec extends ObjectBehavior
 
 
     function it_is_able_to_take_threeds2_data()
-    {        
+    {
 
         $tds2Auth = new ThreeDS2AuthorizationInformation();
         $tds2Auth->setAcsUrl('https://acs.cardinity.com/v2/');
         $tds2Auth->setCreq('eyJyZXR1c...');
-        
-        $this->setThreeDS2AuthorizationInformation($tds2Auth);        
-        $this->getThreeDS2AuthorizationInformation()->shouldReturnAnInstanceOf('Cardinity\Method\Payment\ThreeDS2AuthorizationInformation');
-        $this->getThreeDS2AuthorizationInformation()->shouldReturn($tds2Auth);
-        
+
+        $this->setThreeds2Data($tds2Auth);
+        $this->getThreeds2Data()->shouldReturnAnInstanceOf('Cardinity\Method\Payment\ThreeDS2AuthorizationInformation');
+        $this->getThreeds2Data()->shouldReturn($tds2Auth);
+
     }
 
     function it_is_able_to_serialize_tdsv2(){
@@ -83,14 +83,14 @@ class PaymentSpec extends ObjectBehavior
         $tds2Auth = new ThreeDS2AuthorizationInformation();
         $tds2Auth->setAcsUrl('https://acs.cardinity.com/v2/');
         $tds2Auth->setCreq('eyJyZXR1c...');
-        
-        $this->setThreeDS2AuthorizationInformation($tds2Auth);        
-        $this->getThreeDS2AuthorizationInformation()->shouldReturnAnInstanceOf('Cardinity\Method\Payment\ThreeDS2AuthorizationInformation');
-        $this->getThreeDS2AuthorizationInformation()->shouldReturn($tds2Auth);
-        
-        $this->getThreeDS2AuthorizationInformation()->serialize()->shouldReturn($json);
+
+        $this->setThreeds2Data($tds2Auth);
+        $this->getThreeds2Data()->shouldReturnAnInstanceOf('Cardinity\Method\Payment\ThreeDS2AuthorizationInformation');
+        $this->getThreeds2Data()->shouldReturn($tds2Auth);
+
+        $this->getThreeds2Data()->serialize()->shouldReturn($json);
     }
-    
+
 
     function it_handles_unexpected_values()
     {

--- a/src/Method/Payment/Payment.php
+++ b/src/Method/Payment/Payment.php
@@ -394,7 +394,7 @@ class Payment extends ResultObject
     /**
      * @return ThreeDS2AuthorizationInformation
      */
-    public function getThreeds2data()
+    public function getThreeds2Data()
     {
         return $this->threeDS2AuthorizationInformation;
     }
@@ -403,7 +403,7 @@ class Payment extends ResultObject
      * @param ThreeDS2AuthorizationInformation
      * @return VOID
      */
-    public function setThreeds2data(
+    public function setThreeds2Data(
         ThreeDS2AuthorizationInformation $threeDS2AuthorizationInformation
     ){
         $this->threeDS2AuthorizationInformation = $threeDS2AuthorizationInformation;

--- a/src/Method/ResultObject.php
+++ b/src/Method/ResultObject.php
@@ -6,6 +6,7 @@ use Cardinity\Exception;
 use Cardinity\Method\Payment\AuthorizationInformation;
 use Cardinity\Method\Payment\PaymentInstrumentCard;
 use Cardinity\Method\Payment\PaymentInstrumentRecurring;
+use Cardinity\Method\Payment\ThreeDS2AuthorizationInformation;
 
 abstract class ResultObject implements ResultObjectInterface
 {
@@ -81,6 +82,10 @@ abstract class ResultObject implements ResultObjectInterface
                     $object = new AuthorizationInformation();
                     $object->unserialize(json_encode($value));
                     $value = $object;
+                } elseif ($property == 'threeds2_data') {
+                    $object = new ThreeDS2AuthorizationInformation();
+                    $object->unserialize(json_encode($value));
+                    $value = $object;
                 } elseif ($property == 'payment_instrument') {
                     if (!isset($data->payment_method)) {
                         throw new Exception\Runtime('Property "payment_method" is missing');
@@ -135,7 +140,7 @@ abstract class ResultObject implements ResultObjectInterface
     private function propertyName($method)
     {
         $method = lcfirst(substr($method, 3));
-        $method = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $method));
+        $method = strtolower(preg_replace('/([a-z0-9])([A-Z])/', '$1_$2', $method));
 
         return $method;
     }


### PR DESCRIPTION
Fixes #15.

API uses `threeds2_data`, so its CamelCase variant is `Threeds2Data`.

I've renamed getter/setter, because method name case is important for `ResultObject::serialize()`. PHP methods are case-insensitive, so it is backwards compatible.