### PR TITLE
PHP-549 added exception when a non parsable response recieved

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -142,6 +142,10 @@ class Client
             $this->getOptions($method)
         );
 
+        if(!is_array($result)){
+            throw new Exception\UnexpectedError('Unexpected error :'.$result);
+        }
+
         if ($method instanceof MethodResultCollectionInterface) {
             return $this->mapper->mapCollection($result, $method);
         }

--- a/src/Http/Guzzle/ExceptionMapper.php
+++ b/src/Http/Guzzle/ExceptionMapper.php
@@ -6,6 +6,7 @@ use Cardinity\Method\Error;
 use Cardinity\Method\MethodInterface;
 use Cardinity\Method\ResultObjectMapperInterface;
 use GuzzleHttp\Exception\ClientException;
+use Cardinity\Exception\UnexpectedError;
 
 class ExceptionMapper
 {
@@ -78,6 +79,10 @@ class ExceptionMapper
             $resultObject = $method->createResultObject();
         } else {
             $resultObject = new Error();
+        }
+
+        if(!is_array($response)){
+            throw new UnexpectedError('Unexpected error : "'.$exception->getMessage().'"', $exception->getCode());
         }
 
         $response = $this->resultMapper->map(

--- a/tests/UnexpectedErrorTest.php
+++ b/tests/UnexpectedErrorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Cardinity\Tests;
+
+use Cardinity\Client;
+use Cardinity\Method\Payment;
+
+class UnexpectedErrorTest
+{
+
+    /**
+     * @return void
+     */
+    public function testUnexpectedError()
+    {
+
+        $faultyCient = Client::create([
+            'consumerKey' => 'foo',
+            'consumerSecret' => 'bar',
+            'apiEndpoint' => "https://www.cardinity.com/"
+        ]);
+
+        $method = new Payment\Get('foobar');
+
+        $this->expectException(\Cardinity\Exception\UnexpectedError::class);
+        $faultyCient->call($method);
+    }
+
+}


### PR DESCRIPTION
added exception when exception mapper gets a non json error
added exception when result mapper gets a non json response