### PR TITLE
PHP-689 added threeds status reason parameter, fixed unit test change…

### DIFF
--- a/src/Method/Payment/Payment.php
+++ b/src/Method/Payment/Payment.php
@@ -44,6 +44,10 @@ class Payment extends ResultObject
         Value assigned by Cardinity. */
     private $status;
 
+    /** @type string Payment status reason.
+    Value assigned by Cardinity. */
+    private $threedsStatusReason;
+
     /** @type string Error message.
         Returned only if status is declined.
         Provides human readable information why the payment failed.
@@ -245,6 +249,26 @@ class Payment extends ResultObject
     {
         $this->status = $status;
     }
+
+    /**
+     * Gets the value of status.
+     * @return mixed
+     */
+    public function getThreedsStatusReason()
+    {
+        return $this->threedsStatusReason;
+    }
+
+    /**
+     * Sets the value of threeds status reason.
+     * @param mixed $threedsStatusReason the status reason
+     * @return void
+     */
+    public function setThreedsStatusReason($threedsStatusReason)
+    {
+        $this->threedsStatusReason = $threedsStatusReason;
+    }
+
 
     /**
      * Gets the value of error.

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -242,7 +242,7 @@ class PaymentTest extends ClientTestCase
     {
         $newPaymentParams = $this->paymentParams;
 
-        $newPaymentParams['payment_instrument']['pan'] = '4200000000000018';
+        $newPaymentParams['payment_instrument']['pan'] = '5454545454540018';
         $newPaymentParams['amount'] = 150.23;
 
         $method = new Payment\Create($newPaymentParams);
@@ -254,6 +254,27 @@ class PaymentTest extends ClientTestCase
             $this->assertInstanceOf('Cardinity\Method\Payment\Payment', $result);
             $this->assertSame('declined', $result->getStatus());
             $this->assertSame("03: Do not try again", $result->getMerchantAdviceCode());
+        }
+
+        return $result;
+    }
+
+    public function test3dsStatusReason()
+    {
+        $newPaymentParams = $this->paymentParams;
+
+        $newPaymentParams['payment_instrument']['pan'] = '5454545454540109';
+        $newPaymentParams['amount'] = 150.23;
+
+        $method = new Payment\Create($newPaymentParams);
+
+        try {
+            $result = $this->client->call($method);
+        } catch (\Cardinity\Exception\Declined $e){
+            $result = $e->getResult();
+            $this->assertInstanceOf('Cardinity\Method\Payment\Payment', $result);
+            $this->assertSame('declined', $result->getStatus());
+            $this->assertSame('01: Card authentication failed', $result->getThreedsStatusReason());
         }
 
         return $result;


### PR DESCRIPTION
Added new response parameter  'threeds_status_reason'
Fixed merchant advice code unit test